### PR TITLE
Fix an error when there is no buttons config

### DIFF
--- a/js/dataTables.buttons.js
+++ b/js/dataTables.buttons.js
@@ -48,6 +48,11 @@ var _dtButtons = DataTable.ext.buttons;
  */
 var Buttons = function( dt, config )
 {
+	// If there is no config set it to an empty array
+	if ( typeof( config ) === 'undefined' ) {
+		config = [];	
+	}
+		
 	// Allow a boolean true for defaults
 	if ( config === true ) {
 		config = {};


### PR DESCRIPTION
Fixes an error if the DataTables "dom" has the property for Buttons but there are no buttons config defined.